### PR TITLE
fix: Voltek default imports, ESLint reset, and privacy scrubber tests

### DIFF
--- a/cockpit-ui/lib/alerts/alertManager.ts
+++ b/cockpit-ui/lib/alerts/alertManager.ts
@@ -166,7 +166,6 @@ export async function sendAlertNotification(alert: Alert): Promise<void> {
   // Example Slack webhook (disabled by default)
   if (process.env.SLACK_WEBHOOK_URL) {
     try {
-      const fetch = (await import('node-fetch')).default;
       await fetch(process.env.SLACK_WEBHOOK_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -192,7 +191,6 @@ export async function sendAlertNotification(alert: Alert): Promise<void> {
  */
 export async function monitorAndAlert(healthEndpoint = 'http://localhost:3000/api/mcp/healthz'): Promise<void> {
   try {
-    const fetch = (await import('node-fetch')).default;
     const response = await fetch(healthEndpoint);
 
     if (!response.ok) {

--- a/cockpit-ui/next-env.d.ts
+++ b/cockpit-ui/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/cockpit-ui/tsconfig.json
+++ b/cockpit-ui/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["dom", "dom.iterable", "es2021"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2021"
+    ],
     "jsx": "preserve",
     "module": "esnext",
     "moduleResolution": "bundler",
@@ -15,14 +19,24 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
     "plugins": [
       {
         "name": "next"
       }
-    ]
+    ],
+    "allowJs": true,
+    "isolatedModules": true
   },
-  "include": ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
- Fix privacy scrubber regex pattern ordering in tests: NRIC and UUID patterns now run before the generic phone pattern to prevent false matches
- Fix AWS ARN pattern to handle S3-style ARNs without account ID
- Fix Google API key pattern to match 32 chars after AIza prefix
- Remove node-fetch dependency, use native fetch (Node 18+)
- Include Next.js auto-generated tsconfig updates